### PR TITLE
enhancement: RLS settings appending logic to support multiple migration directories

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { appendRlsSettingsToMigration, extractRlsFields } from ".";
+import { appendRlsSettingsToMigrations, extractRlsFields } from ".";
 
 interface CommandLineArguments {
 	schemaFile: string;
@@ -48,7 +48,7 @@ function main() {
 		console.log("No RLS fields found");
 		return;
 	}
-	appendRlsSettingsToMigration(
+	appendRlsSettingsToMigrations(
 		rlsModels,
 		args.migrationsDir,
 		args.currentSettingIsolation,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import path from 'node:path';
+import path from "node:path";
 import {
 	type FieldDeclaration,
 	type ModelDeclaration,
@@ -40,60 +40,59 @@ export function extractRlsFields(schemaFile: string): RlsModel[] {
 }
 // Appends RLS settings to the each migration file
 export function appendRlsSettingsToMigrations(
-    rlsModels: RlsModel[],
-    migrationsDir: string,
-    currentSettingIsolation: string,
-    currentUser: boolean,
-    currentSettingBypass: string,
+	rlsModels: RlsModel[],
+	migrationsDir: string,
+	currentSettingIsolation: string,
+	currentUser: boolean,
+	currentSettingBypass: string,
 ) {
-    const migrationDirs = findMigrationDirectories(migrationsDir);
-    if (migrationDirs.length === 0) {
-        console.log("No migration directories found");
-        return;
-    }
+	const migrationDirs = findMigrationDirectories(migrationsDir);
+	if (migrationDirs.length === 0) {
+		console.log("No migration directories found");
+		return;
+	}
 
-    for (const dir of migrationDirs) {
-        const migrationFilePath = path.join(migrationsDir, dir, 'migration.sql');
-        if (!fs.existsSync(migrationFilePath)) {
-            console.log(`No migration.sql file found in ${dir}`);
-            continue;
-        }
-        const migrationContent = fs.readFileSync(migrationFilePath, {
+	for (const dir of migrationDirs) {
+		const migrationFilePath = path.join(migrationsDir, dir, "migration.sql");
+		if (!fs.existsSync(migrationFilePath)) {
+			console.log(`No migration.sql file found in ${dir}`);
+			continue;
+		}
+		const migrationContent = fs.readFileSync(migrationFilePath, {
 			encoding: "utf8",
 		});
-        if (migrationContent.includes("ENABLE ROW LEVEL SECURITY")) {
-            console.log(`RLS already enabled in ${dir}`);
-            continue;
-        }
+		if (migrationContent.includes("ENABLE ROW LEVEL SECURITY")) {
+			console.log(`RLS already enabled in ${dir}`);
+			continue;
+		}
 
-        const appendSqls = generateRlsStatements(
-            rlsModels,
-            migrationContent,
-            currentSettingIsolation,
-            currentUser,
-            currentSettingBypass,
-        );
-        if (!appendSqls.length) {
-            console.log(`No matched tables found in ${dir}`);
-            continue;
-        }
+		const appendSqls = generateRlsStatements(
+			rlsModels,
+			migrationContent,
+			currentSettingIsolation,
+			currentUser,
+			currentSettingBypass,
+		);
+		if (!appendSqls.length) {
+			console.log(`No matched tables found in ${dir}`);
+			continue;
+		}
 
-        fs.appendFileSync(
-            migrationFilePath,
-            `\n-- RLS Settings\n${appendSqls.join("\n")}\n`,
-        );
-        console.log(`RLS settings appended to ${dir}/migration.sql`);
-    }
+		fs.appendFileSync(
+			migrationFilePath,
+			`\n-- RLS Settings\n${appendSqls.join("\n")}\n`,
+		);
+		console.log(`RLS settings appended to ${dir}/migration.sql`);
+	}
 }
 
 // Finds the latest migration directory based on naming convention
-function findMigrationDirectories(
-	migrationsDir: string,
-): string[] {
-    return fs.readdirSync(migrationsDir, { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => dirent.name)
-        .sort((a, b) => b.localeCompare(a));
+function findMigrationDirectories(migrationsDir: string): string[] {
+	return fs
+		.readdirSync(migrationsDir, { withFileTypes: true })
+		.filter((dirent) => dirent.isDirectory())
+		.map((dirent) => dirent.name)
+		.sort((a, b) => b.localeCompare(a));
 }
 
 // Generates SQL statements for enabling RLS based on existing migrations and RLS models


### PR DESCRIPTION
@shoito 
This PR enhances the tool to support applying Row-Level Security (RLS) settings across multiple migration directories, addressing the issue raised in #1 .


